### PR TITLE
Add lint_range option for selecting lint range

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -1,6 +1,18 @@
 #!/bin/bash
 set -ex
 
+echo "${linting_path}"
+
+run_swiftlint() {
+    local filename="${1}"
+    local reporter="${2}"
+    local flags="${3}"
+
+    if [[ "${filename##*.}" == "swift" ]]; then
+        swiftlint lint --path "${filename}" --reporter "${reporter}" "${flags}"
+    fi
+}
+
 if [ -z "${linting_path}" ] ; then
   echo " [!] Missing required input: linting_path"
 
@@ -19,4 +31,12 @@ fi
 
 cd "${linting_path}"
 
-swiftlint lint --reporter "${reporter}" ${FLAGS}
+case $lint_range in 
+"changed")
+  git diff --name-only | while read filename; do run_swiftlint "${filename}" "${reporter}" "${FLAGS}"; done
+  git diff --cached --name-only | while read filename; do run_swiftlint "${filename}" "${FLAGS}"; done 
+  ;;
+"all") 
+  swiftlint lint --reporter "${reporter}" ${FLAGS}
+  ;;
+esac

--- a/step.sh
+++ b/step.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -ex
 
-echo "${linting_path}"
-
 run_swiftlint() {
     local filename="${1}"
     local reporter="${2}"

--- a/step.yml
+++ b/step.yml
@@ -44,9 +44,10 @@ inputs:
   - lint_range:
     opts:
       category: Config
-      title: "Lint changed files only"
+      title: "Select option for range of Swiftlint"
       summary: ""
-      description: ""
+      description: |-
+        Take the git diff and only lint those files
       is_required: true
       value_options:
       - "all"

--- a/step.yml
+++ b/step.yml
@@ -33,7 +33,7 @@ toolkit:
     entry_file: step.sh
 
 inputs:
-  - linting_path: /Users/y8k/Development/WisdomConcert-iOS
+  - linting_path:
     opts:
       category: Config
       title: "Select the path where Swiftlint should lint"
@@ -41,7 +41,7 @@ inputs:
       description: ""
       is_required: true
 
-  - lint_range: "all"
+  - lint_range:
     opts:
       category: Config
       title: "Lint changed files only"

--- a/step.yml
+++ b/step.yml
@@ -33,7 +33,7 @@ toolkit:
     entry_file: step.sh
 
 inputs:
-  - linting_path:
+  - linting_path: /Users/y8k/Development/WisdomConcert-iOS
     opts:
       category: Config
       title: "Select the path where Swiftlint should lint"
@@ -41,7 +41,18 @@ inputs:
       description: ""
       is_required: true
 
-  - lint_config_file: $BITRISE_SOURCE_DIR/.swiftlint.yml
+  - lint_range: "all"
+    opts:
+      category: Config
+      title: "Lint changed files only"
+      summary: ""
+      description: ""
+      is_required: true
+      value_options:
+      - "all"
+      - "changed"
+
+  - lint_config_file: /Users/y8k/Development/WisdomConcert-iOS/.swiftlint.yml
     opts:
       category: Config
       title: "Linting configuration file"
@@ -50,7 +61,7 @@ inputs:
         If you use a custom linting configuration for Bitrise, you can specify the path here.
       is_required: false
 
-  - reporter: xcode
+  - reporter: json
     opts:
       category: Config
       description: |-
@@ -65,7 +76,7 @@ inputs:
       - junit
       - emoji
 
-  - strict: "no"
+  - strict: "yes"
     opts:
       category: Config
       description: |-


### PR DESCRIPTION
At most cases, users(developers) want to use swliftlint only diff compare to remote base.
So I added `lint_range` for selecting lint range.