### PR TITLE
Fix step fails on deleted files

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -51,11 +51,11 @@ report_path="${BITRISE_DEPLOY_DIR}/${filename}"
 case $lint_range in 
   "changed")
   echo "Linting diff only"
-    files=$(git diff HEAD^ --name-only -- '*.swift')
+    files=$(git diff HEAD^ --name-only --diff-filter=d -- '*.swift')
 
     echo $files
 
-    for swift_file in $(git diff HEAD^ --name-only -- '*.swift')
+    for swift_file in $(git diff HEAD^ --name-only --diff-filter=d -- '*.swift')
     do 
       swiftlint_output+=$"$(swiftlint lint --path "$swift_file" --reporter ${reporter} ${FLAGS})"
       lint_code=$?


### PR DESCRIPTION
**Bug**

When the range for SwiftLint is set to changed files only `git diff` command takes deleted files into account.
Once SwiftLint tries to lint these files it fails with `Error: No lintable files found at paths:`

**Solution**

Exclude deleted files from `git diff`.