### PR TITLE
Make linting_path optional

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -7,13 +7,13 @@ app:
   - A_SECRET_PARAM: $A_SECRET_PARAM
   # If you want to share this step into a StepLib
   - BITRISE_STEP_ID: swiftlint
-  - BITRISE_STEP_VERSION: "0.10.0"
+  - BITRISE_STEP_VERSION: "0.11.0"
   - BITRISE_STEP_GIT_CLONE_URL: https://github.com/kimdv/bitrise-step-swiftlint.git
   - MY_STEPLIB_REPO_FORK_GIT_URL: git@github.com:kimdv/bitrise-steplib.git
 
 workflows:
   test:
-    steps:   
+    steps:
     - change-workdir:
         title: Switch working dir to test /test dir
         description: |-

--- a/step.sh
+++ b/step.sh
@@ -2,16 +2,15 @@
 
 set -o pipefail
 
-if [ -z "${linting_path}" ] ; then
-  echo " [!] Missing required input: linting_path"
-
-  exit 1
+if [ -n "${linting_path}" ] ; then
+  echo "Changing directory to ${linting_path}"
+  cd "${linting_path}"
 fi
 
 FLAGS=''
 
 if [ -s "${lint_config_file}" ] ; then
-  FLAGS=$FLAGS' --config '"${lint_config_file}"  
+  FLAGS=$FLAGS' --config '"${lint_config_file}"
 fi
 
 if [ "${strict}" = "yes" ] ; then
@@ -23,9 +22,6 @@ if [ "${quiet}" = "yes" ] ; then
   echo "Running quiet mode"
   FLAGS=$FLAGS' --quiet'  
 fi
-
-
-cd "${linting_path}"
 
 filename="swiftlint_report"
 case $reporter in

--- a/step.yml
+++ b/step.yml
@@ -33,13 +33,14 @@ toolkit:
     entry_file: step.sh
 
 inputs:
-  - linting_path:
+  - linting_path: $BITRISE_SOURCE_DIR
     opts:
       category: Config
       title: "Select the path where Swiftlint should lint"
       summary: ""
-      description: ""
-      is_required: true
+      description: |-
+        If you use a custom directory on Bitrise, you can specify the path here.
+      is_required: false
 
   - lint_range: all
     opts:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
0.11.0

### Context
In many projects, `linting_path` is often the same as the `CWD` (current working directory). Even in the testing steps, `swiftlint` will look up for Swift files in the root directory. 

In the bash script, this property is used only to change the working directory (`cd ${linting_path }`), not adding value to the configuration if left blank.

### Changes
- Make the configuration of `linting_path`
- Bump the version to `0.11.0` -- There are no breaking changes since the previous version enforced this option. Making it optional is backward compatible with the major and minor.
- The update has been tested locally
